### PR TITLE
fix naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,5 @@ erl_crash.dump
 *.ez
 
 # Ignore package tarball (built via "mix hex.build").
-multipass_ex-*.tar
+ex_multipass-*.tar
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 
 ## Installation
 
-The package can be installed by adding `multipass_ex` to your list of dependencies in `mix.exs`:
+The package can be installed by adding `ex_multipass` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
   [
-    {:multipass_ex, "~> 0.2"}
+    {:ex_multipass, "~> 0.2"}
   ]
 end
 ```

--- a/config/config.exs
+++ b/config/config.exs
@@ -10,11 +10,11 @@ use Mix.Config
 
 # You can configure your application as:
 #
-#     config :multipass_ex, key: :value
+#     config :ex_multipass, key: :value
 #
 # and access this configuration in your application as:
 #
-#     Application.get_env(:multipass_ex, :key)
+#     Application.get_env(:ex_multipass, :key)
 #
 # You can also configure a 3rd-party app:
 #


### PR DESCRIPTION
## Description of the change

> At some point the name of this package was changed. I am removing the instances where the old package name was used. Its extra problematic due to the fact that the multipass_ex package does exist in hex, it just doesn't work.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets
https://app.clubhouse.io/active-prospect/story/23147/fix-docs-in-ex-multipass-library

## Checklists

### Development and Testing

- [x]  Lint rules pass locally.
- [x]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [x]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [x]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [x]  This branch has been rebased off master to be current.

### Tracking 
- [x]  Issue from Clubhouse has a link to this pull request.
- [x]  This PR has a link to the issue in Clubhouse.

### QA
- [ ]  This branch has been deployed to staging and tested.
